### PR TITLE
remove warnings by ctype.h and yylex() functions, add remove *.dSYM f…

### DIFF
--- a/calc.l
+++ b/calc.l
@@ -1,5 +1,7 @@
 %{
 #include "y.tab.h"
+void yyerror (char *s);
+int yylex();
 %}
 %%
 "print"				   {return print;}

--- a/calc.y
+++ b/calc.y
@@ -1,7 +1,9 @@
 %{
 void yyerror (char *s);
+int yylex();
 #include <stdio.h>     /* C declarations used in actions */
 #include <stdlib.h>
+#include <ctype.h>
 int symbols[52];
 int symbolVal(char symbol);
 void updateSymbolVal(char symbol, int val);

--- a/makefile
+++ b/makefile
@@ -8,5 +8,5 @@ y.tab.c: calc.y
 	yacc -d calc.y
 
 clean: 
-	rm -f lex.yy.c y.tab.c y.tab.h calc
+	rm -rf lex.yy.c y.tab.c y.tab.h calc calc.dSYM
 


### PR DESCRIPTION
# Remove some warnings and Add cleaning option

### Warnings
  * make log
  ```bash
  $ make
  yacc -d calc.y
  lex calc.l
  gcc -g lex.yy.c y.tab.c -o calc
  calc.l:11:8: warning: implicit declaration of function 'yyerror' is invalid in C99 [-Wimplicit-function-declaration]
  {ECHO; yyerror ("unexpected character");}
         ^
  1 warning generated.
  y.tab.c:1249:16: warning: implicit declaration of function 'yylex' is invalid in C99 [-Wimplicit-function-declaration]
        yychar = YYLEX;
                 ^
  y.tab.c:605:16: note: expanded from macro 'YYLEX'
  # define YYLEX yylex ()
                 ^
  calc.y:46:5: warning: implicitly declaring library function 'islower' with type 'int (int)'
        [-Wimplicit-function-declaration]
          if(islower(token)) {
             ^
  calc.y:46:5: note: include the header <ctype.h> or explicitly provide a declaration for 'islower'
  calc.y:48:12: warning: implicitly declaring library function 'isupper' with type 'int (int)'
        [-Wimplicit-function-declaration]
          } else if(isupper(token)) {
                    ^
  calc.y:48:12: note: include the header <ctype.h> or explicitly provide a declaration for 'isupper'
  3 warnings generated.
  ```
### reasons and solving

####  implicitly declaring

  - reason

  | cause | functions |
  | :--- | :--- |
  | ctype.h missing | islower(), isupper() |
  | define missing | yylex() |

  - solve

      1. add `ctype.h` include statement to calc.y
      2. add prototype `int yylex();` defines to calc.l and calc.y

#### temparary files dose not cleaning

  - reason
    in macOS, xcode will be generated *.dSYM folder but cannot cleaning

  - solve
    modify `-r` option to `-rf` and `calc.dSYM` folder to remove file lists

